### PR TITLE
Add legal rules for Brazil, state of Minas Gerais

### DIFF
--- a/legal_rules.csv
+++ b/legal_rules.csv
@@ -27,6 +27,14 @@ AT,,townhall,"[ { ""amenity"": ""townhall"" }, { ""office"": ""government"" } ]"
 AT,,vehicle,"[ { ""shop"": ""car_parts|car_repair"" }, { ""amenity"": ""vehicle_inspection"" } ]",2020-03-16,2020-04-13,open,,https://orf.at/stories/3157719/
 AT,,vending_machine,"[ { ""amenity"": ""vending_machine"" } ]",2020-03-16,2020-04-13,open,,https://orf.at/stories/3157719/
 AT,,default,,2020-04-14,,open,,
+BR,BR-MG,default,,2020-04-28,,closed,,https://www.mg.gov.br/minasconsciente/
+BR,BR-MG,eat,"[ { ""amenity"": ""restaurant|fast_food|cafe|ice_cream"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,food,"[ { ""shop"": ""convenience|supermarket|frozen_food|butcher|cheese|seafood|greengrocer|deli|spices|honey|health_food|pasta|cannery|chocolate|tea|coffee|dairy|confectionery|farm|bakery|pastry"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,financial,"[ { ""amenity"": ""bank"" }, { ""office"": ""financial|insurance"" }, { ""shop"": ""money_lender"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,medical_supply,"[ { ""shop"": ""medical_supply|optician|hearing_aids"" }, { ""craft"": ""optician"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,pharmacy,"[ { ""amenity"": ""pharmacy"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,post_office,"[ { ""amenity"": ""post_office"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
+BR,BR-MG,vehicle,"[ { ""shop"": ""car_parts|car_repair|car"" }, { ""amenity"": ""vehicle_inspection"" }, { ""amenity"": ""car_rental"" } ]",2020-04-28,,only:small_capacity,,https://www.mg.gov.br/minasconsciente/empresarios
 CD,,default,,2020-03-19,2020-04-24,closed,,https://www.facebook.com/107142550625947/posts/209937837013084/?d=n
 CD,,bar,"[ { ""amenity"": ""bar|pub|biergarten"" } ]",2020-03-19,,closed,,https://www.facebook.com/107142550625947/posts/209937837013084/?d=n
 CD,,eat,"[ { ""amenity"": ""restaurant|fast_food|cafe|ice_cream"" } ]",2020-03-19,,"only:delivery,takeaway,drive_through",,https://www.facebook.com/107142550625947/posts/209937837013084/?d=n


### PR DESCRIPTION
I was checking the state government's website and most stores are allowed to open, but should offer hydroalcoholic gel and shouldn't allow customers to enter without masks; I couldn't find a specific OSM key/tag to include in the special restrictions field.

Another thing I'd like to point out is that most restaurant or food places are open, but the state recommends clients to buy their food for takeout or delivery. Because of Ça reste ouvert's usage and it establishing the usage of tags with the `:covid19` suffix, I'd like to propose a new value for `takeout`, `delivery` and `drive_through` during the pandemic: `=preferred`, meaning a place offers the service and it's preferred.

I know that generally tag proposals should be done in the wiki but it's an exceptional time and even though tags with the `:covid19` suffix aren't official, people and maps are using them.